### PR TITLE
ログイン時に指定するキーの名前を変更

### DIFF
--- a/src/auth/local.strategy.ts
+++ b/src/auth/local.strategy.ts
@@ -6,7 +6,7 @@ import { AuthService } from './auth.service';
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
   constructor(private authService: AuthService) {
-    super();
+    super({ usernameField: 'email' });
   }
 
   async validate(email: string, password: string): Promise<any> {


### PR DESCRIPTION
```json
{
  "username": "me@example.com",
  "password": "p@ssword"
}
```

デフォルトだとログイン時に上のような内容を POST させる仕様になっているが、メールアドレスで認証させるので、`username` の部分を `email` に変更した。

```json
{
  "email": "me@example.com",
  "password": "p@ssword"
}
```