### PR TITLE
ログイン中のユーザーの情報を返すルートを追加

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,11 +1,13 @@
 import {
   Controller,
   UseGuards,
+  Get,
   Post,
   HttpCode,
   Request,
 } from '@nestjs/common';
 import { LocalAuthGuard } from './local-auth.guard';
+import { AuthenticatedGuard } from './authenticated.guard';
 
 @Controller()
 export class AuthController {
@@ -13,6 +15,12 @@ export class AuthController {
   @Post('auth/login')
   @HttpCode(200)
   async login(@Request() request: any) {
+    return request.user;
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Get('auth/me')
+  async me(@Request() request: any) {
     return request.user;
   }
 

--- a/src/auth/authenticated.guard.ts
+++ b/src/auth/authenticated.guard.ts
@@ -1,0 +1,10 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthenticatedGuard implements CanActivate {
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+
+    return request.isAuthenticated();
+  }
+}


### PR DESCRIPTION
Passport が提供する機能を使って、ログイン中のユーザー情報を取得し、返す API を作成した。
ログインしていない場合は 401 を返すようにした。