### PR TITLE
ユニークキー制約に抵触した際にエラーレスポンスを返す

### DIFF
--- a/src/registration/registration.controller.ts
+++ b/src/registration/registration.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Post, UsePipes, ValidationPipe } from '@nestjs/common';
+import { BadRequestException, Body, Controller, HttpStatus, Post, UsePipes, ValidationPipe } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { UserRegisteredMail } from '../mail/user-registered.mail';
 import { RegisterUserDto } from './register-user.dto';
+import { EmailMustBeUniqueError } from 'src/users/email-must-be-unique.error';
 
 @Controller('registration')
 export class RegistrationController {
@@ -13,10 +14,21 @@ export class RegistrationController {
   @Post()
   @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
   async store(@Body() registerUserDto: RegisterUserDto) {
-    const user = await this.userService.create(registerUserDto);
+    try {
+      const user = await this.userService.create(registerUserDto);
 
-    this.userRegisteredMail.send(user);
+      this.userRegisteredMail.send(user);
 
-    return user;
+      return user;
+    }
+    catch (e) {
+      if (e instanceof EmailMustBeUniqueError) {
+        throw new BadRequestException({
+          statusCode: HttpStatus.BAD_REQUEST,
+          message: [ e.message ],
+          error: 'Bad Request',
+        });
+      }
+    }
   }
 }

--- a/src/users/email-must-be-unique.error.ts
+++ b/src/users/email-must-be-unique.error.ts
@@ -1,0 +1,9 @@
+export class EmailMustBeUniqueError extends Error {
+  constructor(
+    public value: string,
+    message: string = `email '${value}' is already registered.`,
+  ) {
+    super(message);
+    this.name = 'EmailMustBeUniqueError';
+  }
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { User } from '@prisma/client';
+import { EmailMustBeUniqueError } from './email-must-be-unique.error';
 
 @Injectable()
 export class UsersService {
@@ -20,12 +21,20 @@ export class UsersService {
   }
 
   async create(createUserDto: any): Promise<User> {
-    // TODO: ユニークキー制約の例外処理
-    return this.prisma.user.create({
-      data: {
-        ...createUserDto,
-        password: await bcrypt.hash(createUserDto.password, 10),
-      },
-    });
+    try {
+      const user = await this.prisma.user.create({
+        data: {
+          ...createUserDto,
+          password: await bcrypt.hash(createUserDto.password, 10),
+        },
+      });
+      return user;
+    } catch (e) {
+      if (e.code === 'P2002' && e.meta.target === 'users_email_key') {
+        throw new EmailMustBeUniqueError(createUserDto.email);
+      } else {
+        throw e;
+      }
+    }
   }
 }


### PR DESCRIPTION
Prisma が投げる例外をキャッチして NestJS がエラーレスポンスを返すようにした。
https://www.prisma.io/docs/concepts/components/prisma-client/handling-exceptions-and-errors
https://www.prisma.io/docs/reference/api-reference/error-reference
https://docs.nestjs.com/exception-filters