### PR TITLE
設定ファイルを用意

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
+APP_SECRET=secret
 DATABASE_URL="mysql://johndoe:randompassword@localhost:3306/mydb"
 MAIL_HOST=sandbox.smtp.mailtrap.io
 MAIL_PORT=2525

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nestjs-modules/mailer": "^1.8.1",
     "@nestjs/axios": "^2.0.0",
     "@nestjs/common": "^9.0.0",
+    "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^9.0.0",
     "@nestjs/passport": "^9.0.1",
     "@nestjs/platform-express": "^9.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,7 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import appConfig from './config/app';
+import mailConfig from './config/mail';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
@@ -7,7 +10,15 @@ import { BooksModule } from './books/books.module';
 import { MailModule } from './mail/mail.module';
 
 @Module({
-  imports: [AuthModule, RegistrationModule, BooksModule, MailModule],
+  imports: [
+    ConfigModule.forRoot({
+      load: [appConfig, mailConfig],
+    }),
+    AuthModule,
+    RegistrationModule,
+    BooksModule,
+    MailModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -1,0 +1,6 @@
+import { registerAs } from "@nestjs/config";
+
+export default registerAs('app', () => ({
+  secret: process.env.APP_SECRET,
+  port: parseInt(process.env.APP_SERVER_PORT, 10) || 3000,
+}));

--- a/src/config/mail.ts
+++ b/src/config/mail.ts
@@ -1,0 +1,9 @@
+import { registerAs } from "@nestjs/config";
+
+export default registerAs('mail', () => ({
+  host: process.env.MAIL_HOST || 'sandbox.smtp.mailtrap.io',
+  port: parseInt(process.env.MAIL_PORT, 10) || 2525,
+  username: process.env.MAIL_USERNAME,
+  password: process.env.MAIL_PASSWORD,
+  from: process.env.MAIL_FROM || 'noreply@example.com',
+}));

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -1,30 +1,35 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MailerModule } from '@nestjs-modules/mailer';
-import { UserRegisteredMail } from './user-registered.mail';
 import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
 import { join } from 'path';
+import { UserRegisteredMail } from './user-registered.mail';
 
 @Module({
   imports: [
-    MailerModule.forRoot({
-      transport: {
-        host: process.env.MAIL_HOST,
-        port: parseInt(process.env.MAIL_PORT, 10),
-        auth: {
-          user: process.env.MAIL_USERNAME,
-          pass: process.env.MAIL_PASSWORD,
+    MailerModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        transport: {
+          host: configService.get<string>('mail.host'),
+          port: configService.get<number>('mail.port'),
+          auth: {
+            user: configService.get<string>('mail.username'),
+            pass: configService.get<string>('mail.password'),
+          },
         },
-      },
-      defaults: {
-        from: process.env.MAIL_FROM,
-      },
-      template: {
-        dir: join(__dirname, '/templates'),
-        adapter: new HandlebarsAdapter(),
-        options: {
-          strict: true,
+        defaults: {
+          from: configService.get<string>('mail.from'),
         },
-      },
+        template: {
+          dir: join(__dirname, '/templates'),
+          adapter: new HandlebarsAdapter(),
+          options: {
+            strict: true,
+          },
+        },
+      }),
+      inject: [ConfigService],
     }),
   ],
   providers: [UserRegisteredMail],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,16 @@
 import { NestFactory } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
 import * as session from 'express-session';
 import * as passport from 'passport';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const configService = app.get(ConfigService);
 
   app.use(
     session({
-      secret: process.env.APP_SECRET,
+      secret: configService.get<string>('app.secret'),
       resave: false,
       saveUninitialized: false,
       cookie: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,6 @@ async function bootstrap() {
   app.use(passport.initialize());
   app.use(passport.session());
 
-  await app.listen(3000);
+  await app.listen(configService.get<number>('app.port'));
 }
 bootstrap();

--- a/yarn.lock
+++ b/yarn.lock
@@ -741,6 +741,16 @@
     tslib "2.4.1"
     uuid "9.0.0"
 
+"@nestjs/config@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/config/-/config-2.3.1.tgz#6ac151f818db4ccf987c7ff8ef5b2c1f4eeec913"
+  integrity sha512-Ckzel0NZ9CWhNsLfE1hxfDuxJuEbhQvGxSlmZ1/X8awjRmAA/g3kT6M1+MO1SHj1wMtPyUfd9WpwkiqFbiwQgA==
+  dependencies:
+    dotenv "16.0.3"
+    dotenv-expand "10.0.0"
+    lodash "4.17.21"
+    uuid "9.0.0"
+
 "@nestjs/core@^9.0.0":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-9.2.1.tgz#598e51a421a0aaafc568c1a02499f7c1f9491caf"
@@ -2461,6 +2471,16 @@ domutils@^3.0.1:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
     domhandler "^5.0.1"
+
+dotenv-expand@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
+  integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
+
+dotenv@16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
 editorconfig@^0.15.3:
   version "0.15.3"
@@ -4293,7 +4313,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
`process.env.*` を直接使うのをやめて、設定ファイルから設定を取りだして使うようにした。
この方が、わかりやすく、モックもしやすい。
https://docs.nestjs.com/techniques/configuration

ただし、Prisma の設定を NestJS の設定ファイルを使って行うのは難しそう。
https://zenn.dev/waddy/books/graphql-nestjs-nextjs-bootcamp/viewer/nestjs_configration