### PR TITLE
ファイルアップロード機能の実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/express": "^4.17.13",
     "@types/express-session": "^1.17.6",
     "@types/jest": "29.2.4",
+    "@types/multer": "^1.4.7",
     "@types/node": "18.11.18",
     "@types/nodemailer": "^6.4.7",
     "@types/passport": "^1.0.12",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 generator fabbrica {
-  provider = "prisma-fabbrica"
-  output   = "../src/prisma/fabbrica"
+  provider    = "prisma-fabbrica"
+  output      = "../src/prisma/fabbrica"
   noTranspile = true
 }
 
@@ -14,12 +14,26 @@ datasource db {
 }
 
 model User {
-  id         Int       @id @default(autoincrement())
-  name       String
-  email      String    @unique
-  password   String
-  createdAt  DateTime? @default(now()) @db.Timestamp(0) @map("created_at")
-  updatedAt  DateTime? @default(now()) @db.Timestamp(0) @map("updated_at") @updatedAt
+  id        Int       @id @default(autoincrement())
+  name      String
+  email     String    @unique
+  password  String
+  createdAt DateTime? @default(now()) @map("created_at") @db.Timestamp(0)
+  updatedAt DateTime? @default(now()) @updatedAt @map("updated_at") @db.Timestamp(0)
+  files     File[]
 
   @@map("users")
+}
+
+model File {
+  id        Int       @id @default(autoincrement())
+  author_id Int
+  name      String
+  mime      String
+  content   Bytes
+  createdAt DateTime? @default(now()) @map("created_at") @db.Timestamp(0)
+  updatedAt DateTime? @default(now()) @updatedAt @map("updated_at") @db.Timestamp(0)
+  author    User?     @relation(fields: [author_id], references: [id])
+
+  @@map("files")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { RegistrationModule } from './registration/registration.module';
 import { BooksModule } from './books/books.module';
 import { MailModule } from './mail/mail.module';
 import { ResponsesModule } from './responses/responses.module';
+import { FilesModule } from './files/files.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { ResponsesModule } from './responses/responses.module';
     }),
     AuthModule,
     RegistrationModule,
+    FilesModule,
     BooksModule,
     MailModule,
     ResponsesModule,

--- a/src/files/files.controller.spec.ts
+++ b/src/files/files.controller.spec.ts
@@ -1,0 +1,64 @@
+import { initialize, FileFactory } from '@/prisma/factories';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { PrismaService } from '@/prisma/prisma.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Request, Response } from 'express';
+import { FilesController } from './files.controller';
+import { FilesModule } from './files.module';
+
+describe('FilesController', () => {
+  let prisma: PrismaService;
+  let filesController: FilesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [PrismaModule, FilesModule],
+      controllers: [FilesController],
+      providers: [PrismaService],
+    }).compile();
+
+    prisma = module.get<PrismaService>(PrismaService);
+    filesController = module.get<FilesController>(FilesController);
+
+    initialize({ prisma });
+  });
+
+  it('should be defined', () => {
+    expect(filesController).toBeDefined();
+  });
+
+  describe('show', () => {
+    let id: number;
+    let mockedRequest: Request;
+
+    const mockedResponse = {
+      setHeader: jest.fn(),
+      send: jest.fn(),
+    } as unknown as Response;
+
+    beforeAll(async () => {
+      const file = await FileFactory.create();
+      id = file.id;
+
+      const user = await prisma.user.findUnique({
+        where: { id: file.author_id },
+      });
+      mockedRequest = { user } as unknown as Request;
+    });
+
+    afterAll(() => {
+      prisma.file.deleteMany({ where: {} });
+      prisma.user.deleteMany({ where: {} });
+    });
+
+    it('should send contents', async () => {
+      const spy = jest.spyOn(mockedResponse, 'send');
+
+      await filesController.show(mockedRequest, id, mockedResponse);
+
+      expect(spy).toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/files/files.controller.spec.ts
+++ b/src/files/files.controller.spec.ts
@@ -70,6 +70,7 @@ describe('FilesController', () => {
       const user = await UserFactory.create();
       mockedRequest = { user } as unknown as Request;
 
+      // Controller のテストではバリデーションは行われない
       uploadedFile = {
         originalname: 'NAME',
         mimetype: 'text/plain',

--- a/src/files/files.controller.spec.ts
+++ b/src/files/files.controller.spec.ts
@@ -1,4 +1,4 @@
-import { initialize, FileFactory } from '@/prisma/factories';
+import { initialize, FileFactory, UserFactory } from '@/prisma/factories';
 import { PrismaModule } from '@/prisma/prisma.module';
 import { PrismaService } from '@/prisma/prisma.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -59,6 +59,31 @@ describe('FilesController', () => {
       expect(spy).toHaveBeenCalled();
 
       spy.mockRestore();
+    });
+  });
+
+  describe('create', () => {
+    let uploadedFile: Express.Multer.File;
+    let mockedRequest: Request;
+
+    beforeAll(async () => {
+      const user = await UserFactory.create();
+      mockedRequest = { user } as unknown as Request;
+
+      uploadedFile = {
+        originalname: 'NAME',
+        mimetype: 'text/plain',
+        buffer: Buffer.from('ABC'),
+      } as Express.Multer.File;
+    });
+
+    it('should register the specified file', async () => {
+      const response = await filesController.create(
+        mockedRequest,
+        uploadedFile,
+      );
+
+      expect(response).toBeTruthy();
     });
   });
 });

--- a/src/files/files.controller.ts
+++ b/src/files/files.controller.ts
@@ -1,9 +1,12 @@
 import {
   ClassSerializerInterceptor,
   Controller,
+  FileTypeValidator,
   ForbiddenException,
   Get,
+  MaxFileSizeValidator,
   Param,
+  ParseFilePipe,
   Post,
   Req,
   Res,
@@ -47,7 +50,15 @@ export class FilesController {
   @UseInterceptors(ClassSerializerInterceptor)
   async create(
     @Req() request,
-    @UploadedFile() uploadedFile: Express.Multer.File,
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 20 * 1024 * 1024 }),
+          new FileTypeValidator({ fileType: 'image/jpeg' }),
+        ],
+      }),
+    )
+    uploadedFile: Express.Multer.File,
   ) {
     const file = await this.filesService.create(uploadedFile, request.user);
 

--- a/src/files/files.controller.ts
+++ b/src/files/files.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  ForbiddenException,
+  Get,
+  Param,
+  Req,
+  Res,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { AuthenticatedGuard } from '@/auth/authenticated.guard';
+import { FilesService } from './files.service';
+
+@Controller('files')
+export class FilesController {
+  constructor(private filesService: FilesService) {}
+
+  @Get(':id')
+  @UseGuards(AuthenticatedGuard)
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async show(
+    @Req() request,
+    @Param('id') id: number,
+    @Res() response: Response,
+  ): Promise<void> {
+    const file = await this.filesService.findById(id);
+
+    if (file.author_id !== request.user.id) {
+      throw new ForbiddenException();
+    }
+
+    response.setHeader('Content-Type', file.mime);
+    response.send(file.content);
+  }
+}

--- a/src/files/files.module.ts
+++ b/src/files/files.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { FilesController } from './files.controller';
+import { FilesService } from './files.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [FilesController],
+  providers: [FilesService],
+  exports: [FilesService],
+})
+export class FilesModule {}

--- a/src/files/files.service.spec.ts
+++ b/src/files/files.service.spec.ts
@@ -48,7 +48,12 @@ describe('FilesService', () => {
       });
 
       it('should be found by the given id', async () => {
-        expect(await filesService.findById(id)).toBeTruthy();
+        const file = await filesService.findById(id);
+
+        expect(file).toBeTruthy();
+
+        // File の定義に author が含まれないため any で回避
+        expect((file as any).author.id).toEqual(file.author_id);
       });
     });
   });

--- a/src/files/files.service.spec.ts
+++ b/src/files/files.service.spec.ts
@@ -1,0 +1,54 @@
+import { PrismaModule } from '@/prisma/prisma.module';
+import { PrismaService } from '@/prisma/prisma.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { initialize, FileFactory } from '@/prisma/factories';
+import { FilesService } from './files.service';
+
+describe('FilesService', () => {
+  let prisma: PrismaService;
+  let filesService: FilesService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [PrismaModule],
+      providers: [PrismaService, FilesService],
+    }).compile();
+
+    prisma = module.get<PrismaService>(PrismaService);
+    filesService = module.get<FilesService>(FilesService);
+
+    initialize({ prisma });
+  });
+
+  it('should be defined', () => {
+    expect(filesService).toBeDefined();
+  });
+
+  describe('#findById', () => {
+    describe('when a nonexistent id is specified', () => {
+      const nonexistentId = 0;
+
+      it('should not be found by the given id', async () => {
+        expect(await filesService.findById(nonexistentId)).toBeNull();
+      });
+    });
+
+    describe('when an existing id is specified', () => {
+      let id: number;
+
+      beforeAll(async () => {
+        const file = await FileFactory.create();
+        id = file.id;
+      });
+
+      afterAll(() => {
+        prisma.file.deleteMany({ where: {} });
+        prisma.user.deleteMany({ where: {} });
+      });
+
+      it('should be found by the given id', async () => {
+        expect(await filesService.findById(id)).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -8,6 +8,9 @@ export class FilesService {
 
   async findById(id: number): Promise<File | null> {
     return this.prisma.file.findUnique({
+      include: {
+        author: true,
+      },
       where: { id },
     });
   }

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/prisma/prisma.service';
+import { File } from '@prisma/client';
+
+@Injectable()
+export class FilesService {
+  constructor(private prisma: PrismaService) {}
+
+  async findById(id: number): Promise<File | null> {
+    return this.prisma.file.findUnique({
+      where: { id },
+    });
+  }
+}

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { File } from '@prisma/client';
+import { File, User } from '@prisma/client';
 
 @Injectable()
 export class FilesService {
@@ -9,6 +9,20 @@ export class FilesService {
   async findById(id: number): Promise<File | null> {
     return this.prisma.file.findUnique({
       where: { id },
+    });
+  }
+
+  async create(file: Express.Multer.File, author: User): Promise<File> {
+    return await this.prisma.file.create({
+      data: {
+        author_id: author.id,
+        name: file.originalname,
+        mime: file.mimetype,
+        content: file.buffer,
+      },
+      include: {
+        author: true,
+      },
     });
   }
 }

--- a/src/prisma/fabbrica/index.ts
+++ b/src/prisma/fabbrica/index.ts
@@ -1,4 +1,5 @@
 import type { User } from "@prisma/client";
+import type { File } from "@prisma/client";
 import { Prisma } from "@prisma/client";
 import type { PrismaClient } from "@prisma/client";
 import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, } from "@quramy/prisma-fabbrica/lib/internal";
@@ -10,7 +11,18 @@ type BuildDataOptions = {
 
 const modelFieldDefinitions: ModelWithFields[] = [{
         name: "User",
-        fields: []
+        fields: [{
+                name: "files",
+                type: "File",
+                relationName: "FileToUser"
+            }]
+    }, {
+        name: "File",
+        fields: [{
+                name: "author",
+                type: "User",
+                relationName: "FileToUser"
+            }]
     }];
 
 type UserScalarOrEnumFields = {
@@ -25,6 +37,7 @@ type UserFactoryDefineInput = {
     password?: string;
     createdAt?: Date | null;
     updatedAt?: Date | null;
+    files?: Prisma.FileCreateNestedManyWithoutAuthorInput;
 };
 
 type UserFactoryDefineOptions = {
@@ -95,4 +108,102 @@ function defineUserFactoryInternal({ defaultData: defaultDataResolver }: UserFac
  */
 export function defineUserFactory(options: UserFactoryDefineOptions = {}): UserFactoryInterface {
     return defineUserFactoryInternal(options);
+}
+
+type FileScalarOrEnumFields = {
+    name: string;
+    mime: string;
+    content: Buffer;
+};
+
+type FileauthorFactory = {
+    _factoryFor: "User";
+    build: () => PromiseLike<Prisma.UserCreateNestedOneWithoutFilesInput["create"]>;
+};
+
+type FileFactoryDefineInput = {
+    name?: string;
+    mime?: string;
+    content?: Buffer;
+    createdAt?: Date | null;
+    updatedAt?: Date | null;
+    author?: FileauthorFactory | Prisma.UserCreateNestedOneWithoutFilesInput;
+};
+
+type FileFactoryDefineOptions = {
+    defaultData?: Resolver<FileFactoryDefineInput, BuildDataOptions>;
+};
+
+function isFileauthorFactory(x: FileauthorFactory | Prisma.UserCreateNestedOneWithoutFilesInput | undefined): x is FileauthorFactory {
+    return (x as any)?._factoryFor === "User";
+}
+
+export interface FileFactoryInterface {
+    readonly _factoryFor: "File";
+    build(inputData?: Partial<Prisma.FileCreateInput>): PromiseLike<Prisma.FileCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.FileCreateInput>): PromiseLike<Prisma.FileCreateInput>;
+    buildList(inputData: number | readonly Partial<Prisma.FileCreateInput>[]): PromiseLike<Prisma.FileCreateInput[]>;
+    pickForConnect(inputData: File): Pick<File, "id">;
+    create(inputData?: Partial<Prisma.FileCreateInput>): PromiseLike<File>;
+    createList(inputData: number | readonly Partial<Prisma.FileCreateInput>[]): PromiseLike<File[]>;
+    createForConnect(inputData?: Partial<Prisma.FileCreateInput>): PromiseLike<Pick<File, "id">>;
+}
+
+function autoGenerateFileScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): FileScalarOrEnumFields {
+    return {
+        name: getScalarFieldValueGenerator().String({ modelName: "File", fieldName: "name", isId: false, isUnique: false, seq }),
+        mime: getScalarFieldValueGenerator().String({ modelName: "File", fieldName: "mime", isId: false, isUnique: false, seq }),
+        content: getScalarFieldValueGenerator().Bytes({ modelName: "File", fieldName: "content", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineFileFactoryInternal({ defaultData: defaultDataResolver }: FileFactoryDefineOptions): FileFactoryInterface {
+    const seqKey = {};
+    const getSeq = () => getSequenceCounter(seqKey);
+    const screen = createScreener("File", modelFieldDefinitions);
+    const build = async (inputData: Partial<Prisma.FileCreateInput> = {}) => {
+        const seq = getSeq();
+        const requiredScalarData = autoGenerateFileScalarsOrEnums({ seq });
+        const resolveValue = normalizeResolver<FileFactoryDefineInput, BuildDataOptions>(defaultDataResolver ?? {});
+        const defaultData = await resolveValue({ seq });
+        const defaultAssociations = {
+            author: isFileauthorFactory(defaultData.author) ? {
+                create: await defaultData.author.build()
+            } : defaultData.author
+        };
+        const data: Prisma.FileCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+        return data;
+    };
+    const buildList = (inputData: number | readonly Partial<Prisma.FileCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
+    const pickForConnect = (inputData: File) => ({
+        id: inputData.id
+    });
+    const create = async (inputData: Partial<Prisma.FileCreateInput> = {}) => {
+        const data = await build(inputData).then(screen);
+        return await getClient<PrismaClient>().file.create({ data });
+    };
+    const createList = (inputData: number | readonly Partial<Prisma.FileCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
+    const createForConnect = (inputData: Partial<Prisma.FileCreateInput> = {}) => create(inputData).then(pickForConnect);
+    return {
+        _factoryFor: "File" as const,
+        build,
+        buildList,
+        buildCreateInput: build,
+        pickForConnect,
+        create,
+        createList,
+        createForConnect,
+    };
+}
+
+/**
+ * Define factory for {@link File} model.
+ *
+ * @param options
+ * @returns factory {@link FileFactoryInterface}
+ */
+export function defineFileFactory(options: FileFactoryDefineOptions = {}): FileFactoryInterface {
+    return defineFileFactoryInternal(options);
 }

--- a/src/prisma/factories.ts
+++ b/src/prisma/factories.ts
@@ -1,4 +1,11 @@
-import { defineUserFactory } from './fabbrica';
+import { defineUserFactory, defineFileFactory } from './fabbrica';
 export { initialize } from './fabbrica';
 
 export const UserFactory = defineUserFactory();
+
+export const FileFactory = defineFileFactory({
+  defaultData: {
+    author: UserFactory,
+    content: Buffer.from('ABC'),
+  },
+});

--- a/src/responses/file.response.ts
+++ b/src/responses/file.response.ts
@@ -1,0 +1,22 @@
+import { Exclude } from 'class-transformer';
+import { UserResponse } from './user.response';
+
+export class FileResponse {
+  id: number;
+  author: UserResponse;
+  name: string;
+  mime: string;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+
+  @Exclude()
+  content: Buffer;
+
+  @Exclude()
+  author_id: number;
+
+  constructor(partial: Partial<any>) {
+    Object.assign(this, partial);
+    this.author = new UserResponse(partial.author);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,13 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
+"@types/multer@^1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.7.tgz#89cf03547c28c7bbcc726f029e2a76a7232cc79e"
+  integrity sha512-/SNsDidUFCvqqcWDwxv2feww/yqhNeTRL5CVoL3jU4Goc4kKEL10T7Eye65ZqPNi4HRx8sAEX59pV1aEH7drNA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/node@*":
   version "18.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"


### PR DESCRIPTION
ファイルをアップロードする API と、アップロードしたファイルをダウンロードする API を作成した。
アップロードしたファイルは DB に保存した。
DB のリレーションを試すために、ファイルの登録者を保存して、本人以外がダウンロードできないようにした。
https://docs.nestjs.com/techniques/file-upload